### PR TITLE
Teamspeak3 - Wrong Name of Lock file 

### DIFF
--- a/TeamSpeak3/ts3server
+++ b/TeamSpeak3/ts3server
@@ -19,7 +19,7 @@ servicename="ts3-server"
 # Directories
 rootdir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 selfname="$(basename $0)"
-lockselfname=".${servicename}.lock"
+lockselfname="${servicename}.pid"
 filesdir="${rootdir}/serverfiles"
 systemdir="${filesdir}"
 executabledir="${filesdir}"


### PR DESCRIPTION
For TS3 it must be: ts3server.pid - not .ts3server.lock