### PR TITLE
Added gamemode variable for gmodserver

### DIFF
--- a/GarrysMod/cfg/lgsm-default.cfg
+++ b/GarrysMod/cfg/lgsm-default.cfg
@@ -65,7 +65,7 @@ sv_allowdownload 0
 sbox_noclip 0
 sbox_godmode 0
 sbox_weapons 0
-sbox_plpldamage 0
+sbox_playershurtplayers 0
 sbox_maxprops 100
 sbox_maxragdolls 50
 sbox_maxnpcs 10
@@ -79,8 +79,6 @@ sbox_maxhoverballs 20
 sbox_maxvehicles 1
 sbox_maxbuttons 20
 sbox_maxemitters 0
-sbox_maxspawners 0
-sbox_maxturrets 0
 
 // Misc Config
 exec banned_user.cfg

--- a/GarrysMod/gmodserver
+++ b/GarrysMod/gmodserver
@@ -23,6 +23,7 @@ workshopcollectionid=""
 
 # Start Variables
 defaultmap="gm_construct"
+gamemode="sandbox"
 maxplayers="16"
 port="27015"
 sourcetvport="27020"
@@ -31,7 +32,7 @@ ip="0.0.0.0"
 
 # https://developer.valvesoftware.com/wiki/Command_Line_Options#Source_Dedicated_Server
 fn_parms(){
-parms="-game garrysmod -strictportbind -ip ${ip} -port ${port} +host_workshop_collection ${workshopcollectionid} -authkey ${workshopauth} +clientport ${clientport} +tv_port ${sourcetvport} +map ${defaultmap} +servercfgfile ${servercfg} -maxplayers ${maxplayers}"
+parms="-game garrysmod -strictportbind -ip ${ip} -port ${port} +host_workshop_collection ${workshopcollectionid} -authkey ${workshopauth} +clientport ${clientport} +tv_port ${sourcetvport} +map ${defaultmap} +gamemode ${gamemode} +servercfgfile ${servercfg} -maxplayers ${maxplayers}"
 }
 
 #### Advanced Variables ####


### PR DESCRIPTION
Adding a variable near the top of gmodserver to set the garry's mod gamemode, as well as fixed a few outdated/removed server variables in the default config

Wasn't sure if you wanted to keep all the source server scripts the same or not, but this'd be a really useful feature for anyone running garry's mod servers, nice and easy changing of their gamemode